### PR TITLE
fix(lint): disable Solid-only prop rule for this React project

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
 
   // Code formatting and organization suggestions
   "assist": {
@@ -65,7 +65,9 @@
             // noUnresolvedImports produces false positives for React
             "noUnresolvedImports": "off",
             // Qwik-specific rule not applicable to this React project
-            "useQwikValidLexicalScope": "off"
+            "useQwikValidLexicalScope": "off",
+            // Solid-specific rule - destructuring props is idiomatic in React
+            "noSolidDestructuredProps": "off"
           },
           "style": {
             // noJsxLiterals enforces i18n wrapping not needed in this example repo


### PR DESCRIPTION
## Problem

The `lint` job on `master` is failing. Biome 2.5.4 (bumped in #356) reports four errors from `correctness/noSolidDestructuredProps`:

- `src/App.tsx` — `ProductTableRow({ product })`
- `src/Heading.tsx` — `Heading({ href, text })` (2 errors)
- `src/Layout.tsx` — `Layout({ children })`

## Cause

`noSolidDestructuredProps` is a SolidJS rule. Solid props are reactive getters, so destructuring them severs reactivity — hence the rule. React props are a plain object snapshot per render, so destructuring is idiomatic and costs nothing. The rule does not apply here.

## Fix

Disable the rule in the existing `**/*.tsx` / `**/*.jsx` override, alongside the `useQwikValidLexicalScope` (Qwik) and `noImgElement` (Next.js) exclusions already there for the same reason — framework-specific rules leaking into a React project.

Also bumps the `$schema` pin from 2.5.0 to 2.5.4 to match the installed CLI, silencing a version-mismatch diagnostic.

No source files changed.

## Verification

All three CI lint-job steps run locally against a clean `npm ci`:

```
=== type-check ===  tsc --noEmit                       exit=0
=== lint ===        Checked 25 files in 7ms.           exit=0
=== format ===      Checked 24 files in 13ms.          exit=0
```